### PR TITLE
fix: Fix complete icon not showing

### DIFF
--- a/library/src/main/java/com/github/jorgecastilloprz/completefab/CompleteFABView.java
+++ b/library/src/main/java/com/github/jorgecastilloprz/completefab/CompleteFABView.java
@@ -75,17 +75,10 @@ public class CompleteFABView extends FrameLayout {
   @Override protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
     super.onMeasure(widthMeasureSpec, heightMeasureSpec);
     if (!viewsAdded) {
-      setupContentSize();
       tintCompleteFabWithArcColor();
       setIcon();
       viewsAdded = true;
     }
-  }
-
-  private void setupContentSize() {
-    int contentSize = (int) getResources().getDimension(R.dimen.fab_content_size);
-    int mContentPadding = (getChildAt(0).getMeasuredWidth() - contentSize) / 2;
-    getChildAt(0).setPadding(mContentPadding, mContentPadding, mContentPadding, mContentPadding);
   }
 
   public void animate(AnimatorSet progressArcAnimator) {

--- a/library/src/main/res/layout/complete_fab.xml
+++ b/library/src/main/res/layout/complete_fab.xml
@@ -9,8 +9,9 @@
 
   <ImageView
       android:id="@+id/completeFabIcon"
-      android:layout_width="match_parent"
-      android:layout_height="match_parent"
+      android:layout_width="@dimen/fab_content_size"
+      android:layout_height="@dimen/fab_content_size"
+      android:layout_gravity="center"
       android:src="@drawable/ic_done"
       />
 


### PR DESCRIPTION
Don't set the margins of the complete view in code but instead set size of the complete icon in XML. Content size of a FAB should always be 24dp, regardless of its size.

Seems like setting the padding does somethings strange. Although you set the padding on all sides, the icons gets moved to the lower right (and out of the view), hence the icon is not visible. Honestly, I don't know why this is happening but setting the size of the icon in XML instead seems like an easy solution. Maybe even easier then setting a padding in code in the first place? Let me know what you think!
