### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Add it to your project
 If you are working with gradle, add the dependency to your `build.gradle` file:
 ```groovy
 dependencies{
-    compile 'com.github.jorgecastilloprz:fabprogresscircle:1.01@aar'
+    implementation 'com.github.jorgecastilloprz:fabprogresscircle:1.01@aar'
 }
 ```
 if you are working with maven, do it into your `pom.xml`


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.